### PR TITLE
namespace group routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :users do
-    resources :boards
+    resources :groups
   end
   resource :profile, only: [:show, :edit, :update]
 


### PR DESCRIPTION
Changes the routes for the name spacing group. Just changed it from boards to groups.